### PR TITLE
fix error "undefined method project_formatter"

### DIFF
--- a/lib/text_format_selector_helper_patch.rb
+++ b/lib/text_format_selector_helper_patch.rb
@@ -5,6 +5,7 @@ module TextFormatSelectorHelperPatch
     base.class_eval do
       alias_method_chain :wiki_helper,  :text_format_select
       alias_method_chain :textilizable, :text_format_select
+      alias_method :project_formatter, :project_formatter
     end
   end
 


### PR DESCRIPTION
下記エラーの修正です。
## 環境

Ruby: 2.2.5p319
Redmine: 3.3.0
## 発生状況

TOPページへアクセス
## エラーログ

```
ActionView::Template::Error (undefined method `project_formatter' for #<#<Class:0x00000003e332a0>:0x00000003e3b180>):
    2: 
    3: <div class="splitcontentleft">
    4:   <div class="wiki">
    5:     <%= textilizable Setting.welcome_text %>
    6:   </div>
    7:   <%= call_hook(:view_welcome_index_left) %>
    8: </div>
  app/views/welcome/index.html.erb:5:in `_app_views_welcome_index_html_erb___3857387487437488736_32631700'
  lib/redmine/sudo_mode.rb:63:in `sudo_mode'
```
